### PR TITLE
Modifié t06.html

### DIFF
--- a/lines/t06.html
+++ b/lines/t06.html
@@ -37,7 +37,7 @@
 			</tr>
 			<tr>
 				<td class="title">Matériel</td>
-				<td>Translohr STE6(27 rames au 28/06/2023)</td>
+				<td>Translohr STE6 (27 rames au 28/06/2023)</td>
 			</tr>
 			<tr>
 				<td class="title">Arrêts</td>
@@ -53,7 +53,7 @@
 			</tr>
 			<tr>
 				<td class="title">Communes desservies</td>
-				<td>6<td>
+				<td>6</td>
 			</tr>
 			<tr>
 				<td class="title">Interstation moyenne</td>


### PR DESCRIPTION
Correction de deux erreurs (depuis les commits de Toineau) ;
- Oubli d'une espace
- Balise <td> mal fermée.